### PR TITLE
Switched R5 and R6 labels on .brd

### DIFF
--- a/Hardware/v3/HeatpumpMonitor.b#1
+++ b/Hardware/v3/HeatpumpMonitor.b#1
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE eagle SYSTEM "eagle.dtd">
-<eagle version="7.6.0">
+<eagle version="6.5.0">
 <drawing>
 <settings>
 <setting alwaysvectorfont="no"/>
@@ -3887,9 +3887,6 @@ design rules under a new name.</description>
 <autorouter>
 <pass name="Default">
 <param name="RoutingGrid" value="50mil"/>
-<param name="AutoGrid" value="1"/>
-<param name="Efforts" value="0"/>
-<param name="TopRouterVariant" value="1"/>
 <param name="tpViaShape" value="round"/>
 <param name="PrefDir.1" value="|"/>
 <param name="PrefDir.2" value="0"/>
@@ -4193,11 +4190,11 @@ design rules under a new name.</description>
 <element name="U$1" library="ESP8266-ESP12" package="ESP8266-ESP12" value="ESP8266_ESP-12" x="95" y="24.5" smashed="yes" rot="R180"/>
 <element name="FTDI1" library="JeeLabs" package="MA06-1" value="FTDI" x="93.25" y="26.5" smashed="yes" rot="R180"/>
 <element name="R5" library="rcl" package="0204/7" value="5.6k" x="72.123" y="22.8545" smashed="yes">
-<attribute name="NAME" x="70.075" y="22.3719" size="0.8128" layer="25" font="vector" ratio="20"/>
+<attribute name="NAME" x="70.075" y="24.9119" size="0.8128" layer="25" font="vector" ratio="20"/>
 <attribute name="VALUE" x="72.009" y="22.2885" size="0.8128" layer="27" font="vector" ratio="20"/>
 </element>
 <element name="R6" library="rcl" package="0204/7" value="10k" x="72.123" y="25.418" smashed="yes" rot="R180">
-<attribute name="NAME" x="69.977" y="24.892" size="0.8128" layer="25" font="vector" ratio="20"/>
+<attribute name="NAME" x="69.977" y="22.352" size="0.8128" layer="25" font="vector" ratio="20"/>
 <attribute name="VALUE" x="72.517" y="24.892" size="0.8128" layer="27" font="vector" ratio="20"/>
 </element>
 <element name="JP4" library="SparkFun" package="1X02" value="" x="77.5" y="68" smashed="yes" rot="R90">


### PR DESCRIPTION
The labels for resistors R5 and R6 were switched.